### PR TITLE
Add various svg elements

### DIFF
--- a/mohtml/__init__.py
+++ b/mohtml/__init__.py
@@ -1,8 +1,8 @@
 from bs4 import BeautifulSoup
 
-html_tags = ['a', 'p', 'i', 'b', 'h1','h2','h3','h4','h5','h6','div','span','pre','blockquote','q','ul','ol','li','dl','dt','dd','table','thead','tbody','tfoot','tr','th','td','caption','form','label','select','option','textarea','button','fieldset','legend','article','section','nav','aside','header','footer','main','figure','figcaption','strong','em','mark','code','samp','kbd','var','time','abbr','dfn','sub','sup','audio','video','picture','canvas','details','summary','dialog','script','noscript','template','style','html','head','body']
+html_tags = ['a', 'p', 'i', 'b', 'h1','h2','h3','h4','h5','h6','div','span','pre','blockquote','q','ul','ol','li','dl','dt','dd','table','thead','tbody','tfoot','tr','th','td','caption','form','label','select','option','textarea','button','fieldset','legend','article','section','nav','aside','header','footer','main','figure','figcaption','strong','em','mark','code','samp','kbd','var','time','abbr','dfn','sub','sup','audio','video','picture','canvas','details','summary','dialog','script','noscript','template','style','html','head','body','svg']
 
-self_closing_tags = ['area','base','br','col','embed','hr','img','input','link','meta','param','source','track','wbr']
+self_closing_tags = ['area','base','br','col','embed','hr','img','input','link','meta','param','source','track','wbr','circle','rect','ellipse','line','polyline','polygon','path']
 
 
 def mk_init(class_name): 

--- a/mohtml/__init__.py
+++ b/mohtml/__init__.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 
-html_tags = ['a', 'p', 'i', 'b', 'h1','h2','h3','h4','h5','h6','div','span','pre','blockquote','q','ul','ol','li','dl','dt','dd','table','thead','tbody','tfoot','tr','th','td','caption','form','label','select','option','textarea','button','fieldset','legend','article','section','nav','aside','header','footer','main','figure','figcaption','strong','em','mark','code','samp','kbd','var','time','abbr','dfn','sub','sup','audio','video','picture','canvas','details','summary','dialog','script','noscript','template','style','html','head','body','svg']
+html_tags = ['a', 'p', 'i', 'b', 'h1','h2','h3','h4','h5','h6','div','span','pre','blockquote','q','ul','ol','li','dl','dt','dd','table','thead','tbody','tfoot','tr','th','td','caption','form','label','select','option','textarea','button','fieldset','legend','article','section','nav','aside','header','footer','main','figure','figcaption','strong','em','mark','code','samp','kbd','var','time','abbr','dfn','sub','sup','audio','video','picture','canvas','details','summary','dialog','script','noscript','template','style','html','head','body','svg','g']
 
 self_closing_tags = ['area','base','br','col','embed','hr','img','input','link','meta','param','source','track','wbr','circle','rect','ellipse','line','polyline','polygon','path']
 


### PR DESCRIPTION
Closes https://github.com/koaning/mohtml/issues/8


Example script:

```python
import marimo

__generated_with = "0.9.20"
app = marimo.App(width="medium")


@app.cell
def __():
    import marimo as mo

    from mohtml import rect, svg

    return mo, rect, svg


@app.cell
def __(rect, svg):
    svg(
        rect(
            width=150,
            height=150,
            x=10,
            y=10,
            style="fill:blue;stroke:pink;stroke-width:5;opacity:0.5",
        ),
        width=300,
        height=170,
        xmlns="http://www.w3.org/2000/svg",
    )
    return


@app.cell
def __(mo):
    mo.Html("""
        <svg width="300" height="170" xmlns="http://www.w3.org/2000/svg">
      <rect width="150" height="150" x="10" y="10"
      style="fill:blue;stroke:pink;stroke-width:5;opacity:0.5" />
    </svg>
    """)
    return


@app.cell
def __():
    return


if __name__ == "__main__":
    app.run()
```
